### PR TITLE
Added tests for primitive types (number Vs. string)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,12 @@ deepStrictEqual({foo: {bar: [1, 2]}}, {foo: {bar: [1, 2]}});
 
 deepStrictEqual({foo: {bar: [1, 2]}}, {foo: {bar: [1, 4]}});
 //=> false
+
+deepStrictEqual({foo: {bar: 1}}, {foo: {bar: 1}});
+//=> true
+
+deepStrictEqual({foo: {bar: 1}}, {foo: {bar: '1'}});
+//=> false
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -4,5 +4,7 @@ import fn from './';
 test(t => {
 	t.true(fn({foo: {bar: [1, 2]}}, {foo: {bar: [1, 2]}}));
 	t.false(fn({foo: {bar: [1, 2]}}, {foo: {bar: [1, 3]}}));
+	t.true(fn({foo: {bar: 1}}, {foo: {bar: 1}}));
+	t.false(fn({foo: {bar: 1}}, {foo: {bar: '1'}}));
 	t.end();
 });


### PR DESCRIPTION
Added tests for primitive types because the previous tests also work if strict is set to `false`.
